### PR TITLE
change carpentry lesson value to `lc`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@
 # dc: Data Carpentry
 # lc: Library Carpentry
 # cp: Carpentries (to use for instructor traning for instance)
-carpentry: "swc"
+carpentry: "lc"
 
 # Overall title for pages.
 title: "Introduction to R"


### PR DESCRIPTION
changing value of type of carpentry to 'lc' so the logo and other things in the jekyll template depending on that value work. 