### PR TITLE
add .zenodo.json file for lesson release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,73 @@
+{
+  "contributors": [
+    {
+      "type": "Editor",
+      "name": "Tim Dennis",
+      "orcid": "0000-0001-6632-3812"
+    },
+    {
+      "type": "Editor",
+      "name": "Stéphane Guillou",
+      "orcid": "0000-0001-8992-0951"
+    },
+    {
+      "type": "Editor",
+      "name": "Clarke Iakovakis",
+      "orcid": "0000-0002-9260-8456"
+    }
+  ],
+  "creators": [
+    {
+      "name": "Clarke Iakovakis",
+      "orcid": "0000-0002-9260-8456"
+    },
+    {
+      "name": "Tim Dennis",
+      "orcid": "0000-0001-6632-3812"
+    },
+    {
+      "name": "John Little"
+    },
+    {
+      "name": "Annajiat Alim Rasel",
+      "orcid": "0000-0003-0198-3734"
+    },
+    {
+      "name": "Christian Knudsen"
+    },
+    {
+      "name": "Ariel Deardorff",
+      "orcid": "0000-0001-8930-6089"
+    },
+    {
+      "name": "Christopher Erdmann",
+      "orcid": "0000-0003-2554-180X"
+    },
+    {
+      "name": "John Little"
+    },
+    {
+      "name": "Emily Chambers"
+    },
+    {
+      "name": "Giuseppe Barbieri"
+    },
+    {
+      "name": "Mikala Narlock"
+    },
+    {
+      "name": "Stéphane Guillou",
+      "orcid": "0000-0001-8992-0951"
+    },
+    {
+      "name": "TauriqSalie"
+    },
+    {
+      "name": "Verena Ras",
+      "orcid": "0000-0003-3938-7241"
+    }
+  ],
+  "license": {
+    "id": "CC-BY-4.0"
+  }
+}


### PR DESCRIPTION
Adds a `.zenodo.json` with metadata about contributors, in preparation for the infrastructure transition.