### PR TITLE
Add a section to the intro episode on Getting Help and Generative AI

### DIFF
--- a/episodes/01-intro-to-r.Rmd
+++ b/episodes/01-intro-to-r.Rmd
@@ -475,6 +475,62 @@ How do you use the `digits` parameter in the round function?
 
 
 
+## Other ways to get help
+
+As mentioned above, you can use a question mark `?` to know more about a function (for example, typing `?round`). However, there are several other ways that people often get help when they are stuck with their R code.
+
+* Search the internet: paste the last line of your error message or “R” and a short description of what you want to do into your favourite search engine and you will usually find several examples where other people have encountered the same problem and came looking for help.
+  * Stack Overflow can be particularly helpful for this: answers to questions are presented as a ranked thread ordered according to how useful other users found them to be. You can search using the `[r]` tag. 
+  * **Take care**: copying and pasting code written by somebody else is risky unless you understand exactly what it is doing!
+* Ask somebody “in the real world”. If you have a colleague or friend with more expertise in R than you have, show them the problem you are having and ask them for help.
+* Sometimes, the act of articulating your question can help you to identify what is going wrong. This is known as [“rubber duck debugging”](https://en.wikipedia.org/wiki/Rubber_duck_debugging) among programmers.
+
+### Generative AI
+
+::::::::::::::::::::::::::::: instructor
+
+### Choose how to teach this section
+The section on generative AI is intended to be concise but Instructors may choose to devote more time to the topic in a workshop.
+Depending on your own level of experience and comfort with talking about and using these tools, you could choose to do any of the following:
+
+* Explain how large language models work and are trained, and/or the difference between generative AI, other forms of AI that currently exist, and the limits of what LLMs can do (e.g., they can't "reason").
+* Demonstrate how you recommend that learners use generative AI.
+* Discuss the ethical concerns listed below, as well as others that you are aware of, to help learners make an informed choice about whether or not to use generative AI tools.
+
+This is a fast-moving technology. 
+If you are preparing to teach this section and you feel it has become outdated, please open an issue on the lesson repository to let the Maintainers know and/or a pull request to suggest updates and improvements.
+
+::::::::::::::::::::::::::::::::::::::::
+
+It is increasingly common for people to use _generative AI_ chatbots such as ChatGPT to get help while coding.
+You will probably receive some useful guidance by presenting your error message to the chatbot and asking it what went wrong.
+
+However, the way this help is provided by the chatbot is different.
+Answers on Stack Overflow have (probably) been given by a human as a direct response to the question asked.
+But generative AI chatbots, which are based on advanced statistical models called Large Language Models (or LLMs), respond by generating the _most likely_ sequence of text that would follow the prompt they are given.
+
+While responses from generative AI tools can often be helpful, they are not always reliable. 
+These tools sometimes generate plausible but incorrect or misleading information, so (just as with an answer found on the internet) it is essential to verify their accuracy.
+You need the knowledge and skills to be able to understand these responses, to judge whether or not they are accurate, and to fix any errors in the code it offers you.
+
+In addition to asking for help, programmers can use generative AI tools to generate code from scratch; extend, improve and reorganize existing code; translate code between programming languages; figure out what terms to use in a search of the internet; and more.
+However, there are drawbacks that you should be aware of.
+
+The models used by these tools have been "trained" on very large volumes of data, much of it taken from the internet, and the responses they produce reflect that training data, and may recapitulate its inaccuracies or biases.
+The environmental costs (energy and water use) of LLMs are a lot higher than other technologies, both during development (known as training) and when an individual user uses one (also called inference). For more information see the [AI Environmental Impact Primer](https://huggingface.co/blog/sasha/ai-environment-primer) developed by researchers at HuggingFace, an AI hosting platform. 
+Concerns also exist about the way the data for this training was obtained, with questions raised about whether the people developing the LLMs had permission to use it.
+Other ethical concerns have also been raised, such as reports that workers were exploited during the training process.
+
+**We recommend that you avoid getting help from generative AI during the workshop** for several reasons:
+
+1. For most problems you will encounter at this stage, help and answers can be found among the first results returned by searching the internet.
+2. The foundational knowledge and skills you will learn in this lesson by writing and fixing your own programs  are essential to be able to evaluate the correctness and safety of any code you receive from online help or a generative AI chatbot. 
+   If you choose to use these tools in the future, the expertise you gain from learning and practicing these fundamentals on your own will help you use them more effectively.
+3. As you start out with programming, the mistakes you make will be the kinds that have also been made -- and overcome! -- by everybody else who learned to program before you. 
+  Since these mistakes and the questions you are likely to have at this stage are common, they are also better represented than other, more specialized problems and tasks in the data that was used to train generative AI tools.
+  This means that a generative AI chatbot is _more likely to produce accurate responses_ to questions that novices ask, which could give you a false impression of how reliable they will be when you are ready to do things that are more advanced.
+  
+
 ## Vectors and data types
 
 ```{r, echo=FALSE, purl=TRUE}


### PR DESCRIPTION
Towards the end of the first episode (01-intro-to-r.Rmd), I've added a section called 'Other Ways to get help', which covers content on the use of Generative AI, among other sources. The text included has been discussed and agreed upon on by the Carpentries community.

This section follows on from a more general section on how to get help using R and Rstudio, building upon this foundational knowledge.

The addition of this content is based on conversations that have been made in the Carpentries about adding content on Generative AI and has been rolled out for a number of existing lesson. Links to relevant discussion are provided below.

- [Carpentries Blog post about incorporation content about AI on lessons](https://carpentries.org/blog/2025/03/essential-knowledge-and-common-misconceptions/)
- [Slack message about GenAI updates to Carpentries lessons](https://carpentries.slack.com/archives/C08M2AT8FME/p1743934558385429)
- [Original PR in SW Plotting and Programming in Python](https://github.com/swcarpentry/python-novice-gapminder/pull/697)
